### PR TITLE
fix missing host in location redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tall",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tall",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Promise-based, No-dependency URL unshortner (expander) module for Node.js",
   "main": "lib/index.js",
   "engines": {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -29,3 +29,8 @@ test("it should return the same url if it's not a short url", () => {
     expect(url).toBe('https://www.nodejsdesignpatterns.com/')
   )
 })
+
+test('it should not fail with location without hostname', async () => {
+  const url = await tall('https://www.bustle.com/p/the-best-strategy-board-games-for-adults-15561360')
+  expect(url).toBe('https://www.bustle.com/p/the-10-best-strategy-board-games-for-adults-15561360')
+})

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export const tall = (url, options) => {
     return request({ method, protocol, host, path }, response => {
       if (response.headers.location && opt.maxRedirects) {
         opt.maxRedirects--
-        return resolve(tall(response.headers.location, opt))
+        return resolve(tall(response.headers.location.startsWith('http')?response.headers.location:`${protocol}//${host}${response.headers.location}`,opt))
       }
 
       resolve(url)


### PR DESCRIPTION
some servers return a location which is only the path. tall will fail without a hostname