### PR TITLE
fix example 'With Async await'

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ With Async await:
 ```javascript
 import { tall } from 'tall';
 
-async someFunction() {
+async function someFunction() {
   try {
     const unshortenedUrl = await tall('http://www.loige.link/codemotion-rome-2017');
     console.log('Tall url', unshortenedUrl);


### PR DESCRIPTION
I notice that in the 'Async await' example the **function** keyword in front of the function name was forgotten and It will generate an error when the code was run.