### PR TITLE
Expose all options of http(s).request

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Available options are the following:
 - `headers` (default `{}`): change request headers - e.g. `{'User-Agent': 'your-custom-user-agent'}`
 - `timeout`: (default: `120000`): timeout in milliseconds after which the request will be cancelled
 
+In addition, any other options available on [http.request()](`https://nodejs.org/api/http.html#httprequestoptions-callback`) or `https.request()` are accepted. This for example includes `rejectUnauthorized` to disable certificate checks.
+
 Example:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Available options are the following:
 - `method` (default `"GET"`): any available HTTP method
 - `maxRedirects` (default `3`): the number of maximum redirects that will be followed in case of multiple redirects.
 - `headers` (default `{}`): change request headers - e.g. `{'User-Agent': 'your-custom-user-agent'}`
+- `timeout`: (default: `120000`): timeout in milliseconds after which the request will be cancelled
 
 Example:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,13 @@
 import { URL } from 'url'
 import { request as httpReq } from 'http'
-import { request as httpsReq } from 'https'
+import { request as httpsReq, RequestOptions } from 'https'
 
 export type TallAvailableHTTPMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH'
 
-export interface TallHTTPHeaders {
-    [header: string]: string
-}
 
-export interface TallOptions {
+export interface TallOptions extends RequestOptions {
   method: TallAvailableHTTPMethod
   maxRedirects: number
-  headers: TallHTTPHeaders
   timeout: number
 }
 
@@ -34,10 +30,8 @@ export const tall = (url: string, options?: Partial<TallOptions>): Promise<strin
         port = protocol === 'https:' ? '443' : '80'
       }
 
-      const method = opt.method
       const request = protocol === 'https:' ? httpsReq : httpReq
-      const headers = opt.headers
-      const req = request(url, { method, headers }, response => {
+      const req = request(url, opt, response => {
         if (response.headers.location && opt.maxRedirects) {
           opt.maxRedirects--
           return resolve(


### PR DESCRIPTION
We had the requirement of being able to set `rejectUnauthorized: false` for a specific use case and needed to expose it. Instead of adding it manually to TallOptions, I chose to just expose all the options of https.request, so if any other fine-tuning is needed, it's possible to do without having to do changes in tall.

While I was at it, I've added the `timeout` option to the Readme.

I hope this is an acceptable choice to you. Otherwise, I'd like to have at least `rejectUnauthorized` be exposed.