### PR TITLE
Implemented plugin system

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 13, 14, 15]
+        node: [12, 13, 14, 15, 16, 17]
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ jspm_packages
 
 # Compiled files
 lib/
+
+#vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Let's say we want to add a plugin that allows us to follow HTML meta refresh red
 
 ```typescript
 // metarefresh-plugin.ts
-import { IncomingMessage } from 'node:http'
-import { Follow, Stop } from '../src'
+import { IncomingMessage } from 'http'
+import { Follow, Stop } from 'tall'
 
 export async function metaRefreshPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {
   let html = ''

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Available options are the following:
 - `maxRedirects` (default `3`): the number of maximum redirects that will be followed in case of multiple redirects.
 - `headers` (default `{}`): change request headers - e.g. `{'User-Agent': 'your-custom-user-agent'}`
 - `timeout`: (default: `120000`): timeout in milliseconds after which the request will be cancelled
+- `plugins`: (default: `[locationHeaderPlugin]`): a list of [plugins](#plugins) for adding advanced behaviours
 
 In addition, any other options available on [http.request()](`https://nodejs.org/api/http.html#httprequestoptions-callback`) or `https.request()` are accepted. This for example includes `rejectUnauthorized` to disable certificate checks.
 
@@ -92,6 +93,107 @@ tall('http://www.loige.link/codemotion-rome-2017', {
   .then(unshortenedUrl => console.log('Tall url', unshortenedUrl))
   .catch(err => console.error('AAAW 👻', err))
 ```
+
+
+## Plugins
+
+Since `tall` v5, a plugin system for extending the default behaviour of tall is available.
+
+By default `tall` comes with 1 single plugin, the `locationHeaderPlugin` which is enabled by default. This plugin follows redirects by looking at the `location` header in the HTTP response received from the source URL.
+
+You might want to write your own plugins to have more sophisticated behaviours.
+
+Some example?
+
+ - Normalise the final URL if the final page has a `<link rel="canonical" href="http://example.com/page/" />` tag in the `<head>` of the document
+ - Follow HTML meta refresh redirects (`<meta http-equiv="refresh" content="0;URL='http://example.com/'" />`)
+
+
+## How to write a plugin
+
+A plugin is simply a function with a specific signature:
+
+```typescript
+export interface TallPlugin {
+  (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop>
+}
+```
+
+So the only thing you need to do is to write your custom behaviour following this interface. But let's discuss briefly what the different elements mean here:
+
+  - `url`: Is the current URL being crawled
+  - `response`: is the actual HTTP response object representing the current
+  - `previous`: the decision from the previous plugin execution (continue following a given URL or stop at a given URL)
+
+Every plugin is executed asynchronously, so a plugin returns a Promise that needs to resolve to a `Follow` or a `Stop` decision.
+
+Let's deep dive on these two concepts. `Follow` and `Stop` are defined as _follows_ (touché):
+
+```typescript
+export class Follow {
+  follow: URL
+  constructor (follow: URL) {
+    this.follow = follow
+  }
+}
+
+export class Stop {
+  stop: URL
+  constructor (stop: URL) {
+    this.stop = stop
+  }
+}
+```
+
+`Follow` and `Stop` are effectively simple classes to express an intent: *should we follow the `follow` URL or should we stop at the `stop` URL?*
+
+Plugins are executed following the middleware pattern (or chain of responsability): they are executed in order and the information is propagated from one to the other.
+
+For example if we initialise `tall` with `{ plugins: [plugin1, plugin2] }`, for every URL, `plugin1` will be executed before `plugin2` and the decision of `plugin1` will passed over onto `plugin2` using the `previous`) parameter.
+
+
+## How to write and enable a plugin
+
+Let's say we want to add a plugin that allows us to follow HTML meta refresh redirects, the code could look like this:
+
+```typescript
+// metarefresh-plugin.ts
+import { IncomingMessage } from 'node:http'
+import { Follow, Stop } from '../src'
+
+export async function metaRefreshPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {
+  let html = ''
+  for await (const chunk of response) {
+    html += chunk.toString()
+  }
+
+  // note: this is actually not a great idea, it's best to use something like `cheerio` to properly parse HTML
+  // but for the sake of illustrating how to use plugins this is good enough here...
+  const metaHttpEquivUrl = html.match(/meta +http-equiv="refresh" +content="\d;url=(http[^"]+)"/)?.[1]
+
+  if (metaHttpEquivUrl) {
+    return new Follow(new URL(metaHttpEquivUrl))
+  }
+
+  return previous
+}
+```
+
+Then, this is how you would use your shiny new plugin:
+
+```typescript
+import {tall, locationHeaderPlugin} from 'tall'
+import { metaRefreshPlugin } from './metarefresh-plugin'
+
+const finalUrl = await tall('https://loige.link/senior', { plugins: [locationHeaderPlugin, metaRefreshPlugin] })
+
+console.log(finalUrl)
+```
+
+Note that we have to explicitly pass the `locationHeaderPlugin` if we want to retain `tall` original behaviour.
+
+
+
 
 ## Contributing
 

--- a/examples/metarefresh-plugin.ts
+++ b/examples/metarefresh-plugin.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'node:http'
+import { IncomingMessage } from 'http'
 import { Follow, Stop } from '../src'
 
 export async function metaRefreshPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {

--- a/examples/metarefresh-plugin.ts
+++ b/examples/metarefresh-plugin.ts
@@ -1,0 +1,19 @@
+import { IncomingMessage } from 'node:http'
+import { Follow, Stop } from '../src'
+
+export async function metaRefreshPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {
+  let html = ''
+  for await (const chunk of response) {
+    html += chunk.toString()
+  }
+
+  // note: this is actually not a great idea, it's best to use something like cheerio to parse HTML
+  // but for the sake of illustrating how to use plugins this is good enough here...
+  const metaHttpEquivUrl = html.match(/meta +http-equiv="refresh" +content="\d;url=(http[^"]+)"/)?.[1]
+
+  if (metaHttpEquivUrl) {
+    return new Follow(new URL(metaHttpEquivUrl))
+  }
+
+  return previous
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export interface TallPlugin {
   (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop>
 }
 
-async function locationHeaderPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {
+export async function locationHeaderPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {
   const { protocol, host } = url
 
   if (response.headers.location) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import { URL } from 'url'
-import { request as httpReq, IncomingMessage } from 'http'
-import { request as httpsReq, RequestOptions } from 'https'
+import { request as httpReq, IncomingMessage } from 'node:http'
+import { request as httpsReq, RequestOptions } from 'node:https'
 
 export class Follow {
   follow: URL

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,54 +1,81 @@
 import { URL } from 'url'
-import { request as httpReq } from 'http'
+import { request as httpReq, IncomingMessage } from 'http'
 import { request as httpsReq, RequestOptions } from 'https'
 
-export type TallAvailableHTTPMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH'
+export class Follow {
+  follow: URL
+  constructor (follow: URL) {
+    this.follow = follow
+  }
+}
+
+export class Stop {
+  stop: URL
+  constructor (stop: URL) {
+    this.stop = stop
+  }
+}
+
+export interface TallPlugin {
+  (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop>
+}
+
+async function locationHeaderPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {
+  const { protocol, host } = url
+
+  if (response.headers.location) {
+    const followUrl = new URL(response.headers.location.startsWith('http')
+      ? response.headers.location
+      : `${protocol}//${host}${response.headers.location}`)
+    return new Follow(followUrl)
+  }
+
+  return previous
+}
 
 export interface TallOptions extends RequestOptions {
-  method: TallAvailableHTTPMethod
   maxRedirects: number
-  timeout: number
+  timeout: number,
+  plugins: TallPlugin[],
 }
 
 const defaultOptions: TallOptions = {
   method: 'GET',
   maxRedirects: 3,
   headers: {},
-  timeout: 120000
+  timeout: 120000,
+  plugins: [locationHeaderPlugin]
 }
 
-export const tall = (url: string, options?: Partial<TallOptions>): Promise<string> => {
-  const opt = Object.assign({}, defaultOptions, options)
+function makeRequest (url: URL, options: TallOptions): Promise<IncomingMessage> {
   return new Promise((resolve, reject) => {
-    try {
-      const { protocol, host } = new URL(url)
-
-      let [, port] = host.split(':', 2)
-      if (typeof port === 'undefined') {
-        // if no port is specified set the port based on protocol
-        port = protocol === 'https:' ? '443' : '80'
-      }
-
-      const request = protocol === 'https:' ? httpsReq : httpReq
-      const req = request(url, opt, response => {
-        if (response.headers.location && opt.maxRedirects) {
-          opt.maxRedirects--
-          return resolve(
-            tall(response.headers.location.startsWith('http')
-              ? response.headers.location
-              : `${protocol}//${host}${response.headers.location}`, opt
-            )
-          )
-        }
-
-        resolve(url)
-      })
-      req.on('error', reject)
-      req.setTimeout(opt.timeout, () => req.destroy())
-      req.end()
-      return req
-    } catch (err) {
-      return reject(err)
-    }
+    const request = url.protocol === 'https:' ? httpsReq : httpReq
+    const req = request(url, options as RequestOptions, response => {
+      resolve(response)
+    })
+    req.on('error', reject)
+    req.setTimeout(options.timeout, () => req.destroy())
+    req.end()
   })
+}
+
+export const tall = async (url: string, options?: Partial<TallOptions>): Promise<string> => {
+  const opt = Object.assign({}, defaultOptions, options)
+  if (opt.maxRedirects <= 0) {
+    return url.toString()
+  }
+
+  const parsedUrl = new URL(url)
+  let prev: Stop | Follow = new Stop(parsedUrl)
+  const response = await makeRequest(parsedUrl, opt)
+  for (const plugin of opt.plugins) {
+    prev = await plugin(parsedUrl, response, prev)
+  }
+
+  const maxRedirects = opt.maxRedirects - 1
+  if (prev instanceof Follow) {
+    return await tall(prev.follow.toString(), { ...options, maxRedirects })
+  }
+
+  return prev.stop.toString()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { request as httpReq, IncomingMessage } from 'node:http'
-import { request as httpsReq, RequestOptions } from 'node:https'
+import { request as httpReq, IncomingMessage } from 'http'
+import { request as httpsReq, RequestOptions } from 'https'
 
 export class Follow {
   follow: URL


### PR DESCRIPTION
This PR proposes a new plugin-based implementations that can allow to make `tall` easily extensible without breaking the principles on which it is built:

  - Being small and efficient
  - Zero dependencies

This will enable adding additional interesting behaviours (through dedicated plugins) such as:

  - Follow `http-equiv` meta redirects (proposed in #42)
  - Return canonical URLs

Since implementing this behaviours requires parsing HTML (and therefore implies introducing external dependencies), those behaviours can be built as external plugins and be passed to `tall`.

Once this is finalised and merged #43 could be re-implemented as a plugin

CC: @karlhorky


## Usage

By default the original business logic (follow `location` headers) is now implemented as a plugin which is enabled by default: `locationHeaderPlugin`.

Plugins are effectively executed like middlewares and they have an opportunity to change the current status and decide to **STOP** at the current **url** or **FOLLOW** the current url to look for new indicators that suggest a redirect (`location` headers, `canonical` links, `http-equiv` meta headers, etc.).

This is how the the `locationHeaderPlugin` is currently being implemented:

```typescript
async function locationHeaderPlugin (url: URL, response: IncomingMessage, previous: Follow | Stop): Promise<Follow | Stop> {
  const { protocol, host } = url

  // if there's a location header normalise the URL and follow it
  if (response.headers.location) {
    const followUrl = new URL(response.headers.location.startsWith('http')
      ? response.headers.location
      : `${protocol}//${host}${response.headers.location}`)
    return new Follow(followUrl)
  }

  // otherwise don't change the current result 
  // (which could already have a Stop or a Follow based on the previous iteration)
  return previous
}
```

Let's say we have implemented a new plugin called `httpEquivPlugin` we could enable as follows:

```typescript
import httpEquivPlugin from 'tall-http-equiv',
import {tall, locationHeaderPlugin} from 'tall'

tall('https://example.com', {
  plugins: [locationHeaderPlugin, httpEquivPlugin]
}).then(console.log)
```

## TODO

 - [x] `locationHeaderPlugin` must be exported
 - [x] Updated documentation adding a section on plugins
 - [x] Add more tests to check that the plugin chain behaves as expected