### PR TITLE
Align .editorconfig and Prettier with ESLint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,5 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+quote_type = single
+semi = false

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'none',
+  semi: false
+}
+  


### PR DESCRIPTION
Align configuration for formatting tools in the editor to play nicely with the ESLint config