### PR TITLE
Upgrade to npm@^9.0.0, drop Node.js 17 in favor of 19

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 17, 18]
+        node: [16, 18, 19]
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
           key: nodeModules-${{ matrix.node }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Upgrade npm for older versions of Node.js
-        run: npm install -g npm@^8.5
+        run: npm install -g npm@^9.0.0
         env:
           CI: true
 


### PR DESCRIPTION
Hey @lmammino 👋 Hope you are well.

Since [npm 9.0.0 was released](https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/), I thought it would make sense to upgrade to the newer version.

And because [Node.js 17 is no longer supported](https://endoflife.date/nodejs), I dropped this in favor of Node.js 19.